### PR TITLE
Add unit tests for ParticulierProdIdentityProvider, UserAttributeMapper & UsernameTemplateMapper classes

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -41,6 +41,12 @@
       <artifactId>resteasy-jaxrs</artifactId>
       <version>3.0.26.Final</version>
     </dependency>
+    <dependency>
+        <groupId>junit</groupId>
+        <artifactId>junit</artifactId>
+        <version>4.12</version>
+        <scope>test</scope>
+    </dependency>
   </dependencies>
   <build>
     <plugins>

--- a/src/test/java/fr/insee/keycloak/FranceConnectParticulierProdIdentityProviderFactoryTest.java
+++ b/src/test/java/fr/insee/keycloak/FranceConnectParticulierProdIdentityProviderFactoryTest.java
@@ -1,0 +1,19 @@
+package fr.insee.keycloak;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+public class FranceConnectParticulierProdIdentityProviderFactoryTest {
+
+  @Test
+  public void testGetId() {
+    Assert.assertEquals("franceconnect-particulier",
+      new FranceConnectParticulierProdIdentityProviderFactory().getId());
+  }
+
+  @Test
+  public void testGetName() {
+    Assert.assertEquals("France Connect Particulier (Production)",
+      new FranceConnectParticulierProdIdentityProviderFactory().getName());
+  }
+}

--- a/src/test/java/fr/insee/keycloak/FranceConnectParticulierTestIdentityProviderFactoryTest.java
+++ b/src/test/java/fr/insee/keycloak/FranceConnectParticulierTestIdentityProviderFactoryTest.java
@@ -1,0 +1,19 @@
+package fr.insee.keycloak;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+public class FranceConnectParticulierTestIdentityProviderFactoryTest {
+
+  @Test
+  public void testGetId() {
+    Assert.assertEquals("franceconnect-particulier-test",
+      new FranceConnectParticulierTestIdentityProviderFactory().getId());
+  }
+
+  @Test
+  public void testGetName() {
+    Assert.assertEquals("France Connect Particulier (Integration)",
+      new FranceConnectParticulierTestIdentityProviderFactory().getName());
+  }
+}

--- a/src/test/java/fr/insee/keycloak/FranceConnectUserAttributeMapperTest.java
+++ b/src/test/java/fr/insee/keycloak/FranceConnectUserAttributeMapperTest.java
@@ -1,0 +1,20 @@
+package fr.insee.keycloak;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+public class FranceConnectUserAttributeMapperTest {
+
+  @Test
+  public void testGetCompatibleProviders() {
+    Assert.assertArrayEquals(
+      new String[] {"franceconnect-particulier", "franceconnect-particulier-test"},
+      new FranceConnectUserAttributeMapper().getCompatibleProviders());
+  }
+
+  @Test
+  public void testGetId() {
+    Assert.assertEquals("franceconnect-user-attribute-mapper",
+      new FranceConnectUserAttributeMapper().getId());
+  }
+}

--- a/src/test/java/fr/insee/keycloak/FranceConnectUsernameTemplateMapperTest.java
+++ b/src/test/java/fr/insee/keycloak/FranceConnectUsernameTemplateMapperTest.java
@@ -1,0 +1,20 @@
+package fr.insee.keycloak;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+public class FranceConnectUsernameTemplateMapperTest {
+
+  @Test
+  public void testGetCompatibleProviders() {
+    Assert.assertArrayEquals(
+      new String[] {"franceconnect-particulier", "franceconnect-particulier-test"},
+      new FranceConnectUsernameTemplateMapper().getCompatibleProviders());
+  }
+
+  @Test
+  public void testGetId() {
+    Assert.assertEquals("franceconnect-username-template-mapper",
+      new FranceConnectUsernameTemplateMapper().getId());
+  }
+}


### PR DESCRIPTION
Hi,

Thank you for your submission through our website

These tests have been created by [Diffblue Cover](https://www.diffblue.com/opensource).

Hopefully, these tests should help you detect any regressions caused by future code changes. If you would find it useful to have additional tests written for this repository, I would be more than happy to look at other particular classes that you consider important.