### PR TITLE
Add an option to ignore FranceConnect being not spec compliant

### DIFF
--- a/src/main/java/fr/insee/keycloak/FranceConnectIdentityProvider.java
+++ b/src/main/java/fr/insee/keycloak/FranceConnectIdentityProvider.java
@@ -1,16 +1,27 @@
 package fr.insee.keycloak;
 
+import javax.ws.rs.CookieParam;
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.QueryParam;
 import javax.ws.rs.core.Response;
 import javax.ws.rs.core.UriBuilder;
 import javax.ws.rs.core.UriInfo;
+
 import org.keycloak.broker.oidc.OIDCIdentityProvider;
 import org.keycloak.broker.oidc.OIDCIdentityProviderConfig;
 import org.keycloak.broker.social.SocialIdentityProvider;
+import org.keycloak.events.Errors;
+import org.keycloak.events.EventBuilder;
+import org.keycloak.events.EventType;
 import org.keycloak.jose.jws.JWSInput;
 import org.keycloak.jose.jws.crypto.HMACProvider;
 import org.keycloak.models.KeycloakSession;
 import org.keycloak.models.RealmModel;
 import org.keycloak.models.UserSessionModel;
+import org.keycloak.services.ErrorPage;
+import org.keycloak.services.managers.AuthenticationManager;
+import org.keycloak.services.messages.Messages;
 import org.keycloak.services.resources.IdentityBrokerService;
 import org.keycloak.services.resources.RealmsResource;
 
@@ -23,7 +34,7 @@ public class FranceConnectIdentityProvider extends OIDCIdentityProvider
   protected String logoutUrl;
 
 
-  public FranceConnectIdentityProvider(KeycloakSession session, OIDCIdentityProviderConfig config) {
+  public FranceConnectIdentityProvider(KeycloakSession session, FranceConnectIdentityProviderConfig config) {
     super(session, config);
     
 
@@ -37,6 +48,71 @@ public class FranceConnectIdentityProvider extends OIDCIdentityProvider
     this.getConfig().setValidateSignature(true);
     this.getConfig().setBackchannelSupported(false);
   }
+
+
+  @Override
+    public Object callback(RealmModel realm, AuthenticationCallback callback, EventBuilder event) {
+      
+      return new OIDCEndpoint(callback, realm, event, (FranceConnectIdentityProviderConfig)getConfig());
+    }
+
+    protected class OIDCEndpoint extends Endpoint {
+        FranceConnectIdentityProviderConfig config;
+
+        public OIDCEndpoint(AuthenticationCallback callback, RealmModel realm, EventBuilder event, FranceConnectIdentityProviderConfig config) {
+            super(callback, realm, event);
+            this.config = config;
+        }
+
+
+        @GET
+        @Path("logout_response")
+        public Response logoutResponse(@QueryParam("state") String state) {
+            UserSessionModel userSession;
+            if(state == null){
+              logger.error("state not found in query string");
+              if (config.isIgnoreAbsentStateParameterLogout()){
+                logger.warn("Using usersession from cookie");
+                AuthenticationManager.AuthResult authResult = AuthenticationManager.authenticateIdentityCookie(session, realm, false);
+                if(authResult!=null){
+                  userSession = authResult.getSession();
+                }else{
+                  logger.error("no valid user session");
+                  EventBuilder event = new EventBuilder(realm, session, clientConnection);
+                  event.event(EventType.LOGOUT);
+                  event.error(Errors.USER_SESSION_NOT_FOUND);
+                  return ErrorPage.error(session, null, Response.Status.BAD_REQUEST, Messages.IDENTITY_PROVIDER_UNEXPECTED_ERROR);
+                 }
+              }else{
+                EventBuilder event = new EventBuilder(realm, session, clientConnection);
+                event.event(EventType.LOGOUT);
+                event.error(Errors.USER_SESSION_NOT_FOUND);
+                return ErrorPage.error(session, null, Response.Status.BAD_REQUEST, Messages.IDENTITY_PROVIDER_UNEXPECTED_ERROR);
+              }
+            }else{
+              userSession = session.sessions().getUserSession(realm, state);
+              if (userSession == null) {
+                  logger.error("no valid user session");
+                  EventBuilder event = new EventBuilder(realm, session, clientConnection);
+                  event.event(EventType.LOGOUT);
+                  event.error(Errors.USER_SESSION_NOT_FOUND);
+                  return ErrorPage.error(session, null, Response.Status.BAD_REQUEST, Messages.IDENTITY_PROVIDER_UNEXPECTED_ERROR);
+              }
+              if (userSession.getState() != UserSessionModel.State.LOGGING_OUT) {
+                  logger.error("usersession in different state");
+                  EventBuilder event = new EventBuilder(realm, session, clientConnection);
+                  event.event(EventType.LOGOUT);
+                  event.error(Errors.USER_SESSION_NOT_FOUND);
+                  return ErrorPage.error(session, null, Response.Status.BAD_REQUEST, Messages.SESSION_NOT_ACTIVE);
+              }
+            }
+            return AuthenticationManager.finishBrowserLogout(session, realm, userSession, session.getContext().getUri(), clientConnection, headers);
+        }
+
+    }
+
+
+
   @Override
   public Response keycloakInitiatedBrowserLogout(KeycloakSession session,
       UserSessionModel userSession, UriInfo uriInfo, RealmModel realm) {

--- a/src/main/java/fr/insee/keycloak/FranceConnectIdentityProviderConfig.java
+++ b/src/main/java/fr/insee/keycloak/FranceConnectIdentityProviderConfig.java
@@ -1,0 +1,21 @@
+package fr.insee.keycloak;
+
+import org.keycloak.broker.oidc.OIDCIdentityProviderConfig;
+import org.keycloak.models.IdentityProviderModel;
+
+public class FranceConnectIdentityProviderConfig extends OIDCIdentityProviderConfig {
+
+   public FranceConnectIdentityProviderConfig(IdentityProviderModel identityProviderModel) {
+      super(identityProviderModel);
+   }
+   
+   public boolean isIgnoreAbsentStateParameterLogout() {
+      return Boolean.valueOf(getConfig().get("ignoreAbsentStateParameterLogout"));
+   }
+
+   public void setIgnoreAbsentStateParameterLogout(boolean value){
+      getConfig().put("ignoreAbsentStateParameterLogout", String.valueOf(value));
+   }
+
+   
+}

--- a/src/main/java/fr/insee/keycloak/FranceConnectParticulierProdIdentityProvider.java
+++ b/src/main/java/fr/insee/keycloak/FranceConnectParticulierProdIdentityProvider.java
@@ -7,7 +7,7 @@ public class FranceConnectParticulierProdIdentityProvider extends FranceConnectI
 
 
   public FranceConnectParticulierProdIdentityProvider(KeycloakSession session,
-      OIDCIdentityProviderConfig config) {
+      FranceConnectIdentityProviderConfig config) {
     super(session, config);
     authorizationUrl = "https://app.franceconnect.gouv.fr/api/v1/authorize";
     tokenUrl = "https://app.franceconnect.gouv.fr/api/v1/token";

--- a/src/main/java/fr/insee/keycloak/FranceConnectParticulierProdIdentityProviderFactory.java
+++ b/src/main/java/fr/insee/keycloak/FranceConnectParticulierProdIdentityProviderFactory.java
@@ -22,7 +22,7 @@ public class FranceConnectParticulierProdIdentityProviderFactory
   public FranceConnectParticulierProdIdentityProvider create(KeycloakSession session,
       IdentityProviderModel model) {
     return new FranceConnectParticulierProdIdentityProvider(session,
-        new OIDCIdentityProviderConfig(model));
+        new FranceConnectIdentityProviderConfig(model));
   }
 
   @Override

--- a/src/main/java/fr/insee/keycloak/FranceConnectParticulierTestIdentityProvider.java
+++ b/src/main/java/fr/insee/keycloak/FranceConnectParticulierTestIdentityProvider.java
@@ -6,7 +6,7 @@ import org.keycloak.models.KeycloakSession;
 public class FranceConnectParticulierTestIdentityProvider extends FranceConnectIdentityProvider {
 
   public FranceConnectParticulierTestIdentityProvider(KeycloakSession session,
-      OIDCIdentityProviderConfig config) {
+  FranceConnectIdentityProviderConfig config) {
     super(session, config);
     authorizationUrl = "https://fcp.integ01.dev-franceconnect.fr/api/v1/authorize";
     tokenUrl = "https://fcp.integ01.dev-franceconnect.fr/api/v1/token";

--- a/src/main/java/fr/insee/keycloak/FranceConnectParticulierTestIdentityProviderFactory.java
+++ b/src/main/java/fr/insee/keycloak/FranceConnectParticulierTestIdentityProviderFactory.java
@@ -21,7 +21,7 @@ public class FranceConnectParticulierTestIdentityProviderFactory
   public FranceConnectParticulierTestIdentityProvider create(KeycloakSession session,
       IdentityProviderModel model) {
     return new FranceConnectParticulierTestIdentityProvider(session,
-        new OIDCIdentityProviderConfig(model));
+        new FranceConnectIdentityProviderConfig(model));
   }
 
   @Override

--- a/src/main/resources/theme-resources/resources/partials/realm-identity-provider-franceconnect-particulier-test.html
+++ b/src/main/resources/theme-resources/resources/partials/realm-identity-provider-franceconnect-particulier-test.html
@@ -169,6 +169,13 @@
                 </div>
                 <kc-tooltip>{{:: 'identity-provider.validate-signatures.tooltip' | translate}}</kc-tooltip>
             </div>
+            <div class="form-group">
+                <label class="col-md-2 control-label" for="ignoreAbsentStateParameterLogout">Ignore Absent State Parameter on logout</label>
+                <div class="col-md-6">
+                    <input ng-model="identityProvider.config.ignoreAbsentStateParameterLogout" id="ignoreAbsentStateParameterLogout" onoffswitchvalue on-text="{{:: 'onText' | translate}}" off-text="{{:: 'offText' | translate}}" />
+                </div>
+                <kc-tooltip>Enable to avoid errors when FranceConnect doesn''t return the sate parameter on logout</kc-tooltip>
+            </div>
 
 
             <div class="form-group">

--- a/src/main/resources/theme-resources/resources/partials/realm-identity-provider-franceconnect-particulier.html
+++ b/src/main/resources/theme-resources/resources/partials/realm-identity-provider-franceconnect-particulier.html
@@ -169,6 +169,14 @@
                 </div>
                 <kc-tooltip>{{:: 'identity-provider.validate-signatures.tooltip' | translate}}</kc-tooltip>
             </div>
+            <div class="form-group">
+                <label class="col-md-2 control-label" for="ignoreAbsentStateParameterLogout">Ignore Absent State Parameter on logout</label>
+                <div class="col-md-6">
+                    <input ng-model="identityProvider.config.ignoreAbsentStateParameterLogout" id="ignoreAbsentStateParameterLogout" onoffswitchvalue on-text="{{:: 'onText' | translate}}" off-text="{{:: 'offText' | translate}}" />
+                </div>
+                <kc-tooltip>Enable to avoid errors when FranceConnect doesn''t return the sate parameter on logout</kc-tooltip>
+            </div>
+
 
 
             <div class="form-group">


### PR DESCRIPTION
A new configuration option is added to the provider to ignore the absence of state parameter in query string