### PR TITLE
Adds mappers at the provider creation

### DIFF
--- a/README.en.md
+++ b/README.en.md
@@ -15,7 +15,7 @@
 
 This [Keycloak](https://www.keycloak.org) plugin adds an identity provider allowing to use [France Connect](https://franceconnect.gouv.fr/) services.
 
-[![Build Status](https://travis-ci.org/inseefr/Keycloak-FranceConnect.svg?branch=master)](https://travis-ci.org/inseefr/Keycloak-FranceConnect)
+[![CI Badge](https://github.com/InseeFr/Keycloak-FranceConnect/actions/workflows/ci.yml/badge.svg)](https://github.com/InseeFr/Keycloak-FranceConnect/actions/workflows/ci.yml)
 
 ## Features
 
@@ -26,15 +26,17 @@ This [Keycloak](https://www.keycloak.org) plugin adds an identity provider allow
 
 ## Compatibility
 
-* The version 2.1 and above of this plugin is compatible with Keycloak `9.0.2` and higher.
+* The version 4.0.0 and above of this plugin is compatible with Keycloak `15.0.0` and higher. 
+* The version 2.1 up to 3.0.0 of this plugin is compatible with Keycloak `9.0.2` and higher.
 * The version 2.0 of this plugin is compatible with Keycloak `8.0.1` until `9.0.2`.
 
 ## Migration
 
 If you are already using an older version of the plugin, it's better to delete your configuration to avoid any conflict.
 
+* 2.x/3.x -> 4.x : Delete your identity provider configuration so that the plugin can automatically generate the mappers when saving the configuration and that there are no conflict.
+* 1.x -> 2.x: Check that your identity provider still exists and that the selected France Connect environment is good
 * 1.x -> 1.4: You will need to configure the new eIDAS level in the configuration
-* 1.x -> 2.0+: Check that your identity provider still exists and that the selected France Connect environment is good
 
 ## Installation
 
@@ -74,6 +76,7 @@ You will also find the redirect uri you will need to enter on the France Connect
 #### Mappers
 
 Once the configuration validated, you can add the mappers needed to retrieve the attributes you want from [claims provided by France Connect](https://partenaires.franceconnect.gouv.fr/fcp/fournisseur-service).
+The main mappers are automatically added when creating the identity provider.
 
 Mappers examples:
 * Name : `lastName`, Mapper Type : `Attribute Importer`, Claim : `family_name`, User Attribute Name : `lastName`

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@
 
 Cette extension pour [Keycloak](https://www.keycloak.org) ajoute un fournisseur d'identité permettant d'utiliser les services proposés par [France Connect](https://franceconnect.gouv.fr/).
 
-[![Build Status](https://travis-ci.org/inseefr/Keycloak-FranceConnect.svg?branch=master)](https://travis-ci.org/inseefr/Keycloak-FranceConnect)
+[![CI Badge](https://github.com/InseeFr/Keycloak-FranceConnect/actions/workflows/ci.yml/badge.svg)](https://github.com/InseeFr/Keycloak-FranceConnect/actions/workflows/ci.yml)
 
 
 Pour toutes questions sur l'utilisation de cette extension, n'hésitez pas à ouvrir une [discussion](https://github.com/InseeFr/Keycloak-FranceConnect/discussions).
@@ -40,7 +40,7 @@ Pour toutes questions sur l'utilisation de cette extension, n'hésitez pas à ou
 
 ## Compatibilité
 
-- La version 4.0.0 est compatible avec Keycloak `15.0.0` et supérieur/
+- La version 4.0.0 est compatible avec Keycloak `15.0.0` et supérieur.
 - La version 2.1 jusqu'à 3.0.0 est compatible avec Keycloak `9.0.2` et supérieur.
 - La version 2.0 est compatible avec Keycloak `8.0.1` jusqu'à `9.0.0`.
 
@@ -48,8 +48,9 @@ Pour toutes questions sur l'utilisation de cette extension, n'hésitez pas à ou
 
 Si vous utilisez déjà une ancienne version de l'extension, il est préférable de supprimer votre configuration afin d'éviter tout conflit possible.
 
+* 2.x/3.x -> 4.x : Supprimer votre configuration de fournisseur d'identité afin que le plugin puisse générer automatiquement les mappers lors de la sauvegarde de la configuration et qu'il n'y ait aucun conflit.
+* 1.x -> 2.x : Vérifiez que votre fournisseur d'identité existe et que l'environnement France Connect sélectionné est celui désiré.
 * 1.x -> 1.4 : Vous devez ajouter le niveau eIDAS dans la configuration du fournisseur d'identité.
-* 1.x -> 2.0+ : Vérifiez que votre fournisseur d'identité existe et que l'environnement France Connect sélectionné est celui désiré.
 
 ## Installation
 
@@ -90,6 +91,7 @@ Vous trouverez également l'url de redirection qu'il faudra enregistrer sur le p
 #### Mappers
 
 Une fois la configuration validée, vous pouvez ajouter des mappers afin de récupérer les attributs à partir [des claims fournis par France Connect](https://partenaires.franceconnect.gouv.fr/fcp/fournisseur-service).
+Les principaux mappers sont ajoutés automatiquement lors de la création du fournisseur d'identité.
 
 Exemples de mappers :
 * Name : `lastName`, Mapper Type : `Attribute Importer`, Claim : `family_name`, User Attribute Name : `lastName`
@@ -146,6 +148,7 @@ Vous trouverez également l'url de redirection qu'il faudra enregistrer sur le p
 ##### Mappers
 
 Une fois la configuration validée, vous pouvez ajouter des mappers afin de récupérer les attributs à partir [des claims fournis par France Connect](https://github.com/france-connect/Documentation-AgentConnect/blob/main/doc-fs.md#les-donn%C3%A9es-agent).
+Les principaux mappers sont ajoutés automatiquement lors de la création du fournisseur d'identité.
 
 Exemples de mappers :
 * Name : `lastName`, Mapper Type : `Attribute Importer`, Claim : `family_name`, User Attribute Name : `lastName`

--- a/src/main/java/fr/insee/keycloak/keys/GeneratedRsaKeyFCProviderFactory.java
+++ b/src/main/java/fr/insee/keycloak/keys/GeneratedRsaKeyFCProviderFactory.java
@@ -10,7 +10,7 @@ import java.util.List;
 /**
  * @author <a href="mailto:sthorger@redhat.com">Stian Thorgersen</a>
  */
-public class GeneratedRsaKeyFCProviderFactory extends GeneratedRsaKeyProviderFactory {
+public final class GeneratedRsaKeyFCProviderFactory extends GeneratedRsaKeyProviderFactory {
 
   public static final String ID = "rsa-generated-fc+";
 

--- a/src/main/java/fr/insee/keycloak/mappers/FranceConnectUserAttributeMapper.java
+++ b/src/main/java/fr/insee/keycloak/mappers/FranceConnectUserAttributeMapper.java
@@ -6,7 +6,7 @@ import org.keycloak.broker.oidc.mappers.UserAttributeMapper;
 
 public class FranceConnectUserAttributeMapper extends UserAttributeMapper {
 
-  private static final String MAPPER_NAME = "franceconnect-user-attribute-mapper";
+  public static final String MAPPER_NAME = "franceconnect-user-attribute-mapper";
 
   public static final String[] COMPATIBLE_PROVIDERS =
       new String[]{

--- a/src/main/java/fr/insee/keycloak/mappers/FranceConnectUserAttributeMapper.java
+++ b/src/main/java/fr/insee/keycloak/mappers/FranceConnectUserAttributeMapper.java
@@ -4,11 +4,11 @@ import fr.insee.keycloak.providers.agentconnect.AgentConnectIdentityProviderFact
 import fr.insee.keycloak.providers.franceconnect.FranceConnectIdentityProviderFactory;
 import org.keycloak.broker.oidc.mappers.UserAttributeMapper;
 
-public class FranceConnectUserAttributeMapper extends UserAttributeMapper {
+public final class FranceConnectUserAttributeMapper extends UserAttributeMapper {
 
   public static final String MAPPER_NAME = "franceconnect-user-attribute-mapper";
 
-  public static final String[] COMPATIBLE_PROVIDERS =
+  private static final String[] COMPATIBLE_PROVIDERS =
       new String[]{
           AgentConnectIdentityProviderFactory.AC_PROVIDER_ID,
           FranceConnectIdentityProviderFactory.FC_PROVIDER_ID

--- a/src/main/java/fr/insee/keycloak/mappers/FranceConnectUsernameTemplateMapper.java
+++ b/src/main/java/fr/insee/keycloak/mappers/FranceConnectUsernameTemplateMapper.java
@@ -6,7 +6,7 @@ import org.keycloak.broker.oidc.mappers.UsernameTemplateMapper;
 
 public class FranceConnectUsernameTemplateMapper extends UsernameTemplateMapper {
 
-  private static final String MAPPER_NAME = "franceconnect-username-template-mapper";
+  public static final String MAPPER_NAME = "franceconnect-username-template-mapper";
 
   public static final String[] COMPATIBLE_PROVIDERS =
       new String[]{

--- a/src/main/java/fr/insee/keycloak/mappers/FranceConnectUsernameTemplateMapper.java
+++ b/src/main/java/fr/insee/keycloak/mappers/FranceConnectUsernameTemplateMapper.java
@@ -4,11 +4,11 @@ import fr.insee.keycloak.providers.agentconnect.AgentConnectIdentityProviderFact
 import fr.insee.keycloak.providers.franceconnect.FranceConnectIdentityProviderFactory;
 import org.keycloak.broker.oidc.mappers.UsernameTemplateMapper;
 
-public class FranceConnectUsernameTemplateMapper extends UsernameTemplateMapper {
+public final class FranceConnectUsernameTemplateMapper extends UsernameTemplateMapper {
 
   public static final String MAPPER_NAME = "franceconnect-username-template-mapper";
 
-  public static final String[] COMPATIBLE_PROVIDERS =
+  private static final String[] COMPATIBLE_PROVIDERS =
       new String[]{
           AgentConnectIdentityProviderFactory.AC_PROVIDER_ID,
           FranceConnectIdentityProviderFactory.FC_PROVIDER_ID

--- a/src/main/java/fr/insee/keycloak/providers/agentconnect/AgentConnectIdentityProvider.java
+++ b/src/main/java/fr/insee/keycloak/providers/agentconnect/AgentConnectIdentityProvider.java
@@ -8,9 +8,9 @@ import org.keycloak.models.KeycloakSession;
 
 import javax.ws.rs.core.UriBuilder;
 
-public class AgentConnectIdentityProvider extends AbstractBaseIdentityProvider<AgentConnectIdentityProviderConfig> {
+final class AgentConnectIdentityProvider extends AbstractBaseIdentityProvider<AgentConnectIdentityProviderConfig> {
 
-  public AgentConnectIdentityProvider(KeycloakSession session, AgentConnectIdentityProviderConfig config) {
+  AgentConnectIdentityProvider(KeycloakSession session, AgentConnectIdentityProviderConfig config) {
     super(session, config, Utils.getJsonWebKeySetFrom(config.getJwksUrl(), session));
   }
 

--- a/src/main/java/fr/insee/keycloak/providers/agentconnect/AgentConnectIdentityProviderConfig.java
+++ b/src/main/java/fr/insee/keycloak/providers/agentconnect/AgentConnectIdentityProviderConfig.java
@@ -9,7 +9,7 @@ import java.util.List;
 import static fr.insee.keycloak.providers.agentconnect.AgentConnectIdentityProviderFactory.AC_PROVIDER_MAPPERS;
 import static fr.insee.keycloak.providers.agentconnect.AgentConnectIdentityProviderFactory.DEFAULT_AC_ENVIRONMENT;
 
-class AgentConnectIdentityProviderConfig extends AbstractBaseProviderConfig {
+final class AgentConnectIdentityProviderConfig extends AbstractBaseProviderConfig {
 
   AgentConnectIdentityProviderConfig(IdentityProviderModel identityProviderModel) {
     super(identityProviderModel);

--- a/src/main/java/fr/insee/keycloak/providers/agentconnect/AgentConnectIdentityProviderConfig.java
+++ b/src/main/java/fr/insee/keycloak/providers/agentconnect/AgentConnectIdentityProviderConfig.java
@@ -1,11 +1,15 @@
 package fr.insee.keycloak.providers.agentconnect;
 
 import fr.insee.keycloak.providers.common.AbstractBaseProviderConfig;
+import org.keycloak.models.IdentityProviderMapperModel;
 import org.keycloak.models.IdentityProviderModel;
 
-class AgentConnectIdentityProviderConfig extends AbstractBaseProviderConfig {
+import java.util.List;
 
-  private static final ACEnvironment DEFAULT_AC_ENVIRONMENT = ACEnvironment.INTEGRATION_INTERNET;
+import static fr.insee.keycloak.providers.agentconnect.AgentConnectIdentityProviderFactory.AC_PROVIDER_MAPPERS;
+import static fr.insee.keycloak.providers.agentconnect.AgentConnectIdentityProviderFactory.DEFAULT_AC_ENVIRONMENT;
+
+class AgentConnectIdentityProviderConfig extends AbstractBaseProviderConfig {
 
   AgentConnectIdentityProviderConfig(IdentityProviderModel identityProviderModel) {
     super(identityProviderModel);
@@ -24,5 +28,10 @@ class AgentConnectIdentityProviderConfig extends AbstractBaseProviderConfig {
     );
 
     return agentConnectEnvironment.getProperty(key);
+  }
+
+  @Override
+  protected List<IdentityProviderMapperModel> getDefaultMappers() {
+    return AC_PROVIDER_MAPPERS;
   }
 }

--- a/src/main/java/fr/insee/keycloak/providers/agentconnect/AgentConnectIdentityProviderFactory.java
+++ b/src/main/java/fr/insee/keycloak/providers/agentconnect/AgentConnectIdentityProviderFactory.java
@@ -11,7 +11,7 @@ import java.util.List;
 import static fr.insee.keycloak.providers.common.Utils.createHardcodedAttributeMapper;
 import static fr.insee.keycloak.providers.common.Utils.createUserAttributeMapper;
 
-public class AgentConnectIdentityProviderFactory
+public final class AgentConnectIdentityProviderFactory
     extends AbstractIdentityProviderFactory<AgentConnectIdentityProvider>
     implements SocialIdentityProviderFactory<AgentConnectIdentityProvider> {
 

--- a/src/main/java/fr/insee/keycloak/providers/agentconnect/AgentConnectIdentityProviderFactory.java
+++ b/src/main/java/fr/insee/keycloak/providers/agentconnect/AgentConnectIdentityProviderFactory.java
@@ -2,8 +2,14 @@ package fr.insee.keycloak.providers.agentconnect;
 
 import org.keycloak.broker.provider.AbstractIdentityProviderFactory;
 import org.keycloak.broker.social.SocialIdentityProviderFactory;
+import org.keycloak.models.IdentityProviderMapperModel;
 import org.keycloak.models.IdentityProviderModel;
 import org.keycloak.models.KeycloakSession;
+
+import java.util.List;
+
+import static fr.insee.keycloak.providers.common.Utils.createHardcodedAttributeMapper;
+import static fr.insee.keycloak.providers.common.Utils.createUserAttributeMapper;
 
 public class AgentConnectIdentityProviderFactory
     extends AbstractIdentityProviderFactory<AgentConnectIdentityProvider>
@@ -11,6 +17,15 @@ public class AgentConnectIdentityProviderFactory
 
   public static final String AC_PROVIDER_ID = "agentconnect";
   public static final String AC_PROVIDER_NAME = "Agent Connect";
+
+  static final ACEnvironment DEFAULT_AC_ENVIRONMENT = ACEnvironment.INTEGRATION_INTERNET;
+
+  static final List<IdentityProviderMapperModel> AC_PROVIDER_MAPPERS = List.of(
+      createUserAttributeMapper(AC_PROVIDER_ID, "lastName", "family_name", "lastName"),
+      createUserAttributeMapper(AC_PROVIDER_ID, "firstName", "given_name", "firstName"),
+      createUserAttributeMapper(AC_PROVIDER_ID, "email", "email", "email"),
+      createHardcodedAttributeMapper(AC_PROVIDER_ID, "provider", "provider", "AC")
+  );
 
   @Override
   public String getName() {

--- a/src/main/java/fr/insee/keycloak/providers/common/Utils.java
+++ b/src/main/java/fr/insee/keycloak/providers/common/Utils.java
@@ -1,11 +1,18 @@
 package fr.insee.keycloak.providers.common;
 
+import fr.insee.keycloak.mappers.FranceConnectUserAttributeMapper;
 import org.jboss.logging.Logger;
+import org.keycloak.broker.oidc.mappers.AbstractClaimMapper;
+import org.keycloak.broker.oidc.mappers.UserAttributeMapper;
+import org.keycloak.broker.provider.HardcodedAttributeMapper;
 import org.keycloak.jose.jwk.JSONWebKeySet;
+import org.keycloak.models.IdentityProviderMapperModel;
+import org.keycloak.models.IdentityProviderMapperSyncMode;
 import org.keycloak.models.KeycloakSession;
 import org.keycloak.protocol.oidc.utils.JWKSHttpUtils;
 
 import java.io.IOException;
+import java.util.HashMap;
 import java.util.Properties;
 
 public final class Utils {
@@ -13,6 +20,37 @@ public final class Utils {
   private static final Logger logger = Logger.getLogger(Utils.class);
 
   private Utils() {
+  }
+
+  public static IdentityProviderMapperModel createUserAttributeMapper(String providerId, String mapperName,
+                                                                      String claimAttributeName, String userAttributeName) {
+    var mapper = new IdentityProviderMapperModel();
+
+    mapper.setName(mapperName);
+    mapper.setIdentityProviderMapper(FranceConnectUserAttributeMapper.MAPPER_NAME);
+    mapper.setIdentityProviderAlias(providerId);
+    mapper.setConfig(new HashMap<>());
+    mapper.setSyncMode(IdentityProviderMapperSyncMode.INHERIT);
+    mapper.getConfig().put(AbstractClaimMapper.CLAIM, claimAttributeName);
+    mapper.getConfig().put(UserAttributeMapper.USER_ATTRIBUTE, userAttributeName);
+
+    return mapper;
+  }
+
+  public static IdentityProviderMapperModel createHardcodedAttributeMapper(String providerId, String mapperName,
+                                                                           String attributeName, String attributeValue) {
+
+    var mapper = new IdentityProviderMapperModel();
+
+    mapper.setName(mapperName);
+    mapper.setIdentityProviderMapper(HardcodedAttributeMapper.PROVIDER_ID);
+    mapper.setIdentityProviderAlias(providerId);
+    mapper.setConfig(new HashMap<>());
+    mapper.setSyncMode(IdentityProviderMapperSyncMode.INHERIT);
+    mapper.getConfig().put(HardcodedAttributeMapper.ATTRIBUTE, attributeName);
+    mapper.getConfig().put(HardcodedAttributeMapper.ATTRIBUTE_VALUE, attributeValue);
+
+    return mapper;
   }
 
   public static Properties loadProperties(String propertiesFile) {

--- a/src/main/java/fr/insee/keycloak/providers/franceconnect/FranceConnectIdentityProvider.java
+++ b/src/main/java/fr/insee/keycloak/providers/franceconnect/FranceConnectIdentityProvider.java
@@ -32,12 +32,12 @@ import java.util.Optional;
 import static fr.insee.keycloak.providers.common.EidasLevel.EIDAS1;
 import static javax.ws.rs.core.Response.Status.OK;
 
-public class FranceConnectIdentityProvider extends AbstractBaseIdentityProvider<FranceConnectIdentityProviderConfig> {
+final class FranceConnectIdentityProvider extends AbstractBaseIdentityProvider<FranceConnectIdentityProviderConfig> {
 
   private static final String BROKER_NONCE_PARAM = "BROKER_NONCE";
   private static final MediaType APPLICATION_JWT_TYPE = MediaType.valueOf("application/jwt");
 
-  public FranceConnectIdentityProvider(KeycloakSession session, FranceConnectIdentityProviderConfig config) {
+  FranceConnectIdentityProvider(KeycloakSession session, FranceConnectIdentityProviderConfig config) {
     super(
         session, config,
         useJwks(config) ? Utils.getJsonWebKeySetFrom(config.getJwksUrl(), session) : null

--- a/src/main/java/fr/insee/keycloak/providers/franceconnect/FranceConnectIdentityProviderConfig.java
+++ b/src/main/java/fr/insee/keycloak/providers/franceconnect/FranceConnectIdentityProviderConfig.java
@@ -9,7 +9,7 @@ import java.util.List;
 import static fr.insee.keycloak.providers.franceconnect.FranceConnectIdentityProviderFactory.DEFAULT_FC_ENVIRONMENT;
 import static fr.insee.keycloak.providers.franceconnect.FranceConnectIdentityProviderFactory.FC_PROVIDER_MAPPERS;
 
-class FranceConnectIdentityProviderConfig extends AbstractBaseProviderConfig {
+final class FranceConnectIdentityProviderConfig extends AbstractBaseProviderConfig {
 
   FranceConnectIdentityProviderConfig(IdentityProviderModel identityProviderModel) {
     super(identityProviderModel);

--- a/src/main/java/fr/insee/keycloak/providers/franceconnect/FranceConnectIdentityProviderConfig.java
+++ b/src/main/java/fr/insee/keycloak/providers/franceconnect/FranceConnectIdentityProviderConfig.java
@@ -1,11 +1,15 @@
 package fr.insee.keycloak.providers.franceconnect;
 
 import fr.insee.keycloak.providers.common.AbstractBaseProviderConfig;
+import org.keycloak.models.IdentityProviderMapperModel;
 import org.keycloak.models.IdentityProviderModel;
 
-class FranceConnectIdentityProviderConfig extends AbstractBaseProviderConfig {
+import java.util.List;
 
-  private static final FCEnvironment DEFAULT_FC_ENVIRONMENT = FCEnvironment.INTEGRATION_V1;
+import static fr.insee.keycloak.providers.franceconnect.FranceConnectIdentityProviderFactory.DEFAULT_FC_ENVIRONMENT;
+import static fr.insee.keycloak.providers.franceconnect.FranceConnectIdentityProviderFactory.FC_PROVIDER_MAPPERS;
+
+class FranceConnectIdentityProviderConfig extends AbstractBaseProviderConfig {
 
   FranceConnectIdentityProviderConfig(IdentityProviderModel identityProviderModel) {
     super(identityProviderModel);
@@ -23,5 +27,10 @@ class FranceConnectIdentityProviderConfig extends AbstractBaseProviderConfig {
     );
 
     return franceConnectEnvironment.getProperty(key);
+  }
+
+  @Override
+  protected List<IdentityProviderMapperModel> getDefaultMappers() {
+    return FC_PROVIDER_MAPPERS;
   }
 }

--- a/src/main/java/fr/insee/keycloak/providers/franceconnect/FranceConnectIdentityProviderFactory.java
+++ b/src/main/java/fr/insee/keycloak/providers/franceconnect/FranceConnectIdentityProviderFactory.java
@@ -2,8 +2,14 @@ package fr.insee.keycloak.providers.franceconnect;
 
 import org.keycloak.broker.provider.AbstractIdentityProviderFactory;
 import org.keycloak.broker.social.SocialIdentityProviderFactory;
+import org.keycloak.models.IdentityProviderMapperModel;
 import org.keycloak.models.IdentityProviderModel;
 import org.keycloak.models.KeycloakSession;
+
+import java.util.List;
+
+import static fr.insee.keycloak.providers.common.Utils.createHardcodedAttributeMapper;
+import static fr.insee.keycloak.providers.common.Utils.createUserAttributeMapper;
 
 public class FranceConnectIdentityProviderFactory
     extends AbstractIdentityProviderFactory<FranceConnectIdentityProvider>
@@ -11,6 +17,15 @@ public class FranceConnectIdentityProviderFactory
 
   public static final String FC_PROVIDER_ID = "franceconnect-particulier";
   public static final String FC_PROVIDER_NAME = "France Connect Particulier";
+
+  static final FCEnvironment DEFAULT_FC_ENVIRONMENT = FCEnvironment.INTEGRATION_V1;
+
+  static final List<IdentityProviderMapperModel> FC_PROVIDER_MAPPERS = List.of(
+      createUserAttributeMapper(FC_PROVIDER_ID, "lastName", "family_name", "lastName"),
+      createUserAttributeMapper(FC_PROVIDER_ID, "firstName", "given_name", "firstName"),
+      createUserAttributeMapper(FC_PROVIDER_ID, "email", "email", "email"),
+      createHardcodedAttributeMapper(FC_PROVIDER_ID, "provider", "provider", "FC")
+  );
 
   @Override
   public String getName() {

--- a/src/main/java/fr/insee/keycloak/providers/franceconnect/FranceConnectIdentityProviderFactory.java
+++ b/src/main/java/fr/insee/keycloak/providers/franceconnect/FranceConnectIdentityProviderFactory.java
@@ -11,7 +11,7 @@ import java.util.List;
 import static fr.insee.keycloak.providers.common.Utils.createHardcodedAttributeMapper;
 import static fr.insee.keycloak.providers.common.Utils.createUserAttributeMapper;
 
-public class FranceConnectIdentityProviderFactory
+public final class FranceConnectIdentityProviderFactory
     extends AbstractIdentityProviderFactory<FranceConnectIdentityProvider>
     implements SocialIdentityProviderFactory<FranceConnectIdentityProvider> {
 

--- a/src/test/java/fr/insee/keycloak/providers/agentconnect/AgentConnectIdentityProviderConfigTest.java
+++ b/src/test/java/fr/insee/keycloak/providers/agentconnect/AgentConnectIdentityProviderConfigTest.java
@@ -4,10 +4,14 @@ import fr.insee.keycloak.providers.common.EidasLevel;
 import org.junit.jupiter.api.DisplayNameGeneration;
 import org.junit.jupiter.api.DisplayNameGenerator.ReplaceUnderscores;
 import org.junit.jupiter.api.Test;
+import org.keycloak.models.RealmModel;
 
 import static fr.insee.keycloak.providers.agentconnect.ACFixture.givenConfigForIntegrationAndEidasLevel2;
 import static fr.insee.keycloak.providers.agentconnect.ACFixture.givenConfigWithSelectedEnvAndSelectedEidasLevel;
+import static fr.insee.keycloak.providers.agentconnect.AgentConnectIdentityProviderFactory.AC_PROVIDER_MAPPERS;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
 
 @DisplayNameGeneration(ReplaceUnderscores.class)
 class AgentConnectIdentityProviderConfigTest {
@@ -65,5 +69,23 @@ class AgentConnectIdentityProviderConfigTest {
     var config = givenConfigForIntegrationAndEidasLevel2();
 
     assertThat(config.isBackchannelSupported()).isFalse();
+  }
+
+  @Test
+  void should_create_identity_mappers_when_saving_configuration_for_the_first_time() {
+    var unsavedConfig = givenConfigForIntegrationAndEidasLevel2();
+    var realm = mock(RealmModel.class);
+
+    unsavedConfig.validate(realm);
+
+    verify(realm, times(AC_PROVIDER_MAPPERS.size())).addIdentityProviderMapper(any());
+
+    var alreadySavedConfig = givenConfigForIntegrationAndEidasLevel2();
+    var unusedRealm = mock(RealmModel.class);
+    alreadySavedConfig.getConfig().put("isCreated", "true");
+
+    alreadySavedConfig.validate(unusedRealm);
+
+    verify(unusedRealm, never()).addIdentityProviderMapper(any());
   }
 }

--- a/src/test/java/fr/insee/keycloak/providers/franceconnect/FranceConnectIdentityProviderConfigTest.java
+++ b/src/test/java/fr/insee/keycloak/providers/franceconnect/FranceConnectIdentityProviderConfigTest.java
@@ -4,10 +4,14 @@ import fr.insee.keycloak.providers.common.EidasLevel;
 import org.junit.jupiter.api.DisplayNameGeneration;
 import org.junit.jupiter.api.DisplayNameGenerator.ReplaceUnderscores;
 import org.junit.jupiter.api.Test;
+import org.keycloak.models.RealmModel;
 
 import static fr.insee.keycloak.providers.franceconnect.FCFixture.givenConfigForIntegrationV2AndEidasLevel2;
 import static fr.insee.keycloak.providers.franceconnect.FCFixture.givenConfigWithSelectedEnvAndSelectedEidasLevel;
+import static fr.insee.keycloak.providers.franceconnect.FranceConnectIdentityProviderFactory.FC_PROVIDER_MAPPERS;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
 
 @DisplayNameGeneration(ReplaceUnderscores.class)
 class FranceConnectIdentityProviderConfigTest {
@@ -65,5 +69,23 @@ class FranceConnectIdentityProviderConfigTest {
     var config = givenConfigForIntegrationV2AndEidasLevel2();
 
     assertThat(config.isBackchannelSupported()).isFalse();
+  }
+
+  @Test
+  void should_create_identity_mappers_when_saving_configuration_for_the_first_time() {
+    var unsavedConfig = givenConfigForIntegrationV2AndEidasLevel2();
+    var realm = mock(RealmModel.class);
+
+    unsavedConfig.validate(realm);
+
+    verify(realm, times(FC_PROVIDER_MAPPERS.size())).addIdentityProviderMapper(any());
+
+    var alreadySavedConfig = givenConfigForIntegrationV2AndEidasLevel2();
+    var unusedRealm = mock(RealmModel.class);
+    alreadySavedConfig.getConfig().put("isCreated", "true");
+
+    alreadySavedConfig.validate(unusedRealm);
+
+    verify(unusedRealm, never()).addIdentityProviderMapper(any());
   }
 }


### PR DESCRIPTION
Resolves #12 

Adds `email`, `lastName`, `firstName` & `provider` mappers at identity provider (FC & AC) creation.

Please delete manually added mappers before FC plugin update. (mapper name must be unique and it can raise exception if mappers already exist)