### PR TITLE
Migrate to keycloak 22 and remove wildfly (jdk17)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,10 +23,10 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-maven-
 
-      - name: Set up JDK 11
+      - name: Set up JDK 17
         uses: actions/setup-java@v1
         with:
-          java-version: 11
+          java-version: 17
 
       - name: Build with Maven
         run: ./mvnw -B clean verify

--- a/.github/workflows/tag.yml
+++ b/.github/workflows/tag.yml
@@ -22,10 +22,10 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-maven-
 
-      - name: Set up JDK 11
+      - name: Set up JDK 17
         uses: actions/setup-java@v1
         with:
-          java-version: 11
+          java-version: 17
 
       - id: get_version
         run: echo ::set-output name=VERSION::$(echo $GITHUB_REF | cut -d / -f 3)

--- a/.mvn/wrapper/maven-wrapper.properties
+++ b/.mvn/wrapper/maven-wrapper.properties
@@ -1,2 +1,2 @@
-distributionUrl=https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.8.3/apache-maven-3.8.3-bin.zip
+distributionUrl=https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.9.3/apache-maven-3.9.3-bin.zip
 wrapperUrl=https://repo.maven.apache.org/maven2/io/takari/maven-wrapper/0.5.6/maven-wrapper-0.5.6.jar

--- a/pom.xml
+++ b/pom.xml
@@ -56,28 +56,27 @@
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
-    <maven.compiler.source>11</maven.compiler.source>
-    <maven.compiler.target>11</maven.compiler.target>
+    <maven.compiler.source>17</maven.compiler.source>
+    <maven.compiler.target>17</maven.compiler.target>
 
-    <maven.clean.plugin.version>3.1.0</maven.clean.plugin.version>
-    <maven.compiler.plugin.version>3.8.1</maven.compiler.plugin.version>
-    <maven.resources.plugin.version>3.2.0</maven.resources.plugin.version>
-    <maven.surefire.plugin.version>3.0.0-M5</maven.surefire.plugin.version>
-    <maven.jar.plugin.version>3.2.0</maven.jar.plugin.version>
-    <maven.install.plugin.version>3.0.0-M1</maven.install.plugin.version>
-    <maven.source.plugin.version>3.2.1</maven.source.plugin.version>
-    <maven.javadoc.plugin.version>3.3.1</maven.javadoc.plugin.version>
-    <wildfly.maven.plugin.version>2.1.0.Final</wildfly.maven.plugin.version>
+    <maven.clean.plugin.version>3.3.1</maven.clean.plugin.version>
+    <maven.compiler.plugin.version>3.11.0</maven.compiler.plugin.version>
+    <maven.resources.plugin.version>3.3.1</maven.resources.plugin.version>
+    <maven.surefire.plugin.version>3.1.2</maven.surefire.plugin.version>
+    <maven.jar.plugin.version>3.3.0</maven.jar.plugin.version>
+    <maven.install.plugin.version>3.1.1</maven.install.plugin.version>
+    <maven.source.plugin.version>3.3.0</maven.source.plugin.version>
+    <maven.javadoc.plugin.version>3.5.0</maven.javadoc.plugin.version>
 
-    <keycloak.version>21.0.1</keycloak.version>
+    <keycloak.version>22.0.0</keycloak.version>
 
     <!-- Testing Tools -->
-    <junit.jupiter.version>5.8.1</junit.jupiter.version>
-    <assertj.version>3.21.0</assertj.version>
-    <mockito.version>4.0.0</mockito.version>
+    <junit.jupiter.version>5.10.0</junit.jupiter.version>
+    <assertj.version>3.24.2</assertj.version>
+    <mockito.version>5.4.0</mockito.version>
 
     <!-- Helper to build public/private keys for testing -->
-    <nimbus.jose-jwt.version>9.15.2</nimbus.jose-jwt.version>
+    <nimbus.jose-jwt.version>9.31</nimbus.jose-jwt.version>
   </properties>
 
   <build>
@@ -134,14 +133,6 @@
     </pluginManagement>
 
     <plugins>
-      <plugin>
-        <groupId>org.wildfly.plugins</groupId>
-        <artifactId>wildfly-maven-plugin</artifactId>
-        <configuration>
-          <skip>false</skip>
-        </configuration>
-      </plugin>
-
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-source-plugin</artifactId>

--- a/src/main/java/fr/insee/keycloak/providers/agentconnect/AgentConnectIdentityProvider.java
+++ b/src/main/java/fr/insee/keycloak/providers/agentconnect/AgentConnectIdentityProvider.java
@@ -2,7 +2,7 @@ package fr.insee.keycloak.providers.agentconnect;
 
 import fr.insee.keycloak.providers.common.AbstractBaseIdentityProvider;
 import fr.insee.keycloak.providers.common.Utils;
-import javax.ws.rs.core.UriBuilder;
+import jakarta.ws.rs.core.UriBuilder;
 import org.keycloak.OAuth2Constants;
 import org.keycloak.broker.provider.AuthenticationRequest;
 import org.keycloak.models.KeycloakSession;

--- a/src/main/java/fr/insee/keycloak/providers/common/AbstractBaseIdentityProvider.java
+++ b/src/main/java/fr/insee/keycloak/providers/common/AbstractBaseIdentityProvider.java
@@ -2,18 +2,11 @@ package fr.insee.keycloak.providers.common;
 
 import static fr.insee.keycloak.providers.common.Utils.transcodeSignatureToDER;
 import static org.keycloak.util.JWKSUtils.getKeyWrappersForUse;
-import static org.keycloak.util.JWKSUtils.getKeysForUse;
 
 import java.nio.charset.StandardCharsets;
 import java.security.PublicKey;
 import java.security.Signature;
 import java.util.Optional;
-import javax.ws.rs.GET;
-import javax.ws.rs.Path;
-import javax.ws.rs.QueryParam;
-import javax.ws.rs.core.Response;
-import javax.ws.rs.core.UriBuilder;
-import javax.ws.rs.core.UriInfo;
 
 import org.keycloak.broker.oidc.AbstractOAuth2IdentityProvider;
 import org.keycloak.broker.oidc.OIDCIdentityProvider;
@@ -39,6 +32,13 @@ import org.keycloak.services.managers.AuthenticationManager;
 import org.keycloak.services.messages.Messages;
 import org.keycloak.services.resources.IdentityBrokerService;
 import org.keycloak.services.resources.RealmsResource;
+
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.QueryParam;
+import jakarta.ws.rs.core.Response;
+import jakarta.ws.rs.core.UriBuilder;
+import jakarta.ws.rs.core.UriInfo;
 
 public abstract class AbstractBaseIdentityProvider<T extends AbstractBaseProviderConfig>
     extends OIDCIdentityProvider implements SocialIdentityProvider<OIDCIdentityProviderConfig> {

--- a/src/main/java/fr/insee/keycloak/providers/franceconnect/FranceConnectIdentityProvider.java
+++ b/src/main/java/fr/insee/keycloak/providers/franceconnect/FranceConnectIdentityProvider.java
@@ -1,17 +1,17 @@
 package fr.insee.keycloak.providers.franceconnect;
 
 import static fr.insee.keycloak.providers.common.EidasLevel.EIDAS1;
-import static javax.ws.rs.core.Response.Status.OK;
+import static jakarta.ws.rs.core.Response.Status.OK;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import fr.insee.keycloak.providers.common.AbstractBaseIdentityProvider;
 import fr.insee.keycloak.providers.common.Utils;
 import java.io.IOException;
 import java.util.Optional;
-import javax.ws.rs.core.HttpHeaders;
-import javax.ws.rs.core.MediaType;
-import javax.ws.rs.core.UriBuilder;
-import javax.xml.bind.DatatypeConverter;
+import jakarta.ws.rs.core.HttpHeaders;
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.UriBuilder;
+import jakarta.xml.bind.DatatypeConverter;
 import org.keycloak.OAuth2Constants;
 import org.keycloak.broker.oidc.mappers.AbstractJsonUserAttributeMapper;
 import org.keycloak.broker.provider.AuthenticationRequest;

--- a/src/test/java/fr/insee/keycloak/providers/agentconnect/AgentConnectIdentityProviderTest.java
+++ b/src/test/java/fr/insee/keycloak/providers/agentconnect/AgentConnectIdentityProviderTest.java
@@ -13,8 +13,8 @@ import org.keycloak.connections.httpclient.HttpClientProvider;
 import org.keycloak.models.KeycloakSession;
 import org.mockito.Mockito;
 
-import javax.ws.rs.core.HttpHeaders;
-import javax.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.HttpHeaders;
+import jakarta.ws.rs.core.MediaType;
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.util.Map;

--- a/src/test/java/fr/insee/keycloak/providers/franceconnect/FranceConnectIdentityProviderTest.java
+++ b/src/test/java/fr/insee/keycloak/providers/franceconnect/FranceConnectIdentityProviderTest.java
@@ -19,7 +19,7 @@ import org.keycloak.models.KeycloakSession;
 import org.keycloak.representations.JsonWebToken;
 import org.mockito.Mockito;
 
-import javax.ws.rs.core.HttpHeaders;
+import jakarta.ws.rs.core.HttpHeaders;
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.util.Map;

--- a/src/test/java/fr/insee/keycloak/utils/KeycloakFixture.java
+++ b/src/test/java/fr/insee/keycloak/utils/KeycloakFixture.java
@@ -13,7 +13,7 @@ import org.keycloak.services.DefaultKeycloakSession;
 import org.keycloak.vault.DefaultVaultStringSecret;
 import org.keycloak.vault.VaultTranscriber;
 
-import javax.ws.rs.core.UriInfo;
+import jakarta.ws.rs.core.UriInfo;
 import java.security.Security;
 import java.util.Optional;
 


### PR DESCRIPTION
Migration en keycloak 22
Suppression de wildfly PLugin
Passage en jdk 17 
Montée de version de dépendances du pom