### PR TITLE
Add EIDAS level and FranceConnect environment options in admin console

### DIFF
--- a/src/main/java/fr/insee/keycloak/providers/agentconnect/AgentConnectIdentityProviderConfig.java
+++ b/src/main/java/fr/insee/keycloak/providers/agentconnect/AgentConnectIdentityProviderConfig.java
@@ -1,10 +1,15 @@
 package fr.insee.keycloak.providers.agentconnect;
 
 import fr.insee.keycloak.providers.common.AbstractBaseProviderConfig;
+import fr.insee.keycloak.providers.common.EidasLevel;
 import org.keycloak.models.IdentityProviderMapperModel;
 import org.keycloak.models.IdentityProviderModel;
+import org.keycloak.provider.ProviderConfigProperty;
+import org.keycloak.provider.ProviderConfigurationBuilder;
 
 import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import static fr.insee.keycloak.providers.agentconnect.AgentConnectIdentityProviderFactory.AC_PROVIDER_MAPPERS;
 import static fr.insee.keycloak.providers.agentconnect.AgentConnectIdentityProviderFactory.DEFAULT_AC_ENVIRONMENT;
@@ -33,5 +38,32 @@ final class AgentConnectIdentityProviderConfig extends AbstractBaseProviderConfi
   @Override
   protected List<IdentityProviderMapperModel> getDefaultMappers() {
     return AC_PROVIDER_MAPPERS;
+  }
+
+  public static List<ProviderConfigProperty> getConfigProperties() {
+    List<String> environments = Stream.of(ACEnvironment.values())
+        .map(Enum::name)
+        .collect(Collectors.toList());
+
+    List<String> eidasLevels = Stream.of(EidasLevel.values())
+        .map(Enum::name)
+        .collect(Collectors.toList());
+
+    return ProviderConfigurationBuilder.create()
+        .property().name(ACEnvironment.ENVIRONMENT_PROPERTY_NAME)
+        .label("Environnement FranceConnect")
+        .helpText("Permet de choisir l'environnement FranceConnect. Effet : change les urls vers FranceConnect.")
+        .type(ProviderConfigProperty.LIST_TYPE)
+        .options(environments)
+        .defaultValue(DEFAULT_AC_ENVIRONMENT)
+        .add()
+        .property().name(EidasLevel.EIDAS_LEVEL_PROPERTY_NAME)
+        .label("Niveau de garantie eIDAS")
+        .helpText("Permet de fixer le niveau de garantie du compte utilisateur souhaité. Effet : désactive des fournisseurs d'identités (FI) sur la page de login FranceConnect.\"")
+        .type(ProviderConfigProperty.LIST_TYPE)
+        .options(eidasLevels)
+        .defaultValue(EidasLevel.EIDAS1)
+        .add()
+        .build();
   }
 }

--- a/src/main/java/fr/insee/keycloak/providers/agentconnect/AgentConnectIdentityProviderFactory.java
+++ b/src/main/java/fr/insee/keycloak/providers/agentconnect/AgentConnectIdentityProviderFactory.java
@@ -5,6 +5,7 @@ import org.keycloak.broker.social.SocialIdentityProviderFactory;
 import org.keycloak.models.IdentityProviderMapperModel;
 import org.keycloak.models.IdentityProviderModel;
 import org.keycloak.models.KeycloakSession;
+import org.keycloak.provider.ProviderConfigProperty;
 
 import java.util.List;
 
@@ -45,5 +46,10 @@ public final class AgentConnectIdentityProviderFactory
   @Override
   public AgentConnectIdentityProviderConfig createConfig() {
     return new AgentConnectIdentityProviderConfig();
+  }
+
+  @Override
+  public List<ProviderConfigProperty> getConfigProperties() {
+    return AgentConnectIdentityProviderConfig.getConfigProperties();
   }
 }

--- a/src/main/java/fr/insee/keycloak/providers/franceconnect/FranceConnectIdentityProviderConfig.java
+++ b/src/main/java/fr/insee/keycloak/providers/franceconnect/FranceConnectIdentityProviderConfig.java
@@ -5,8 +5,14 @@ import static fr.insee.keycloak.providers.franceconnect.FranceConnectIdentityPro
 
 import fr.insee.keycloak.providers.common.AbstractBaseProviderConfig;
 import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import fr.insee.keycloak.providers.common.EidasLevel;
 import org.keycloak.models.IdentityProviderMapperModel;
 import org.keycloak.models.IdentityProviderModel;
+import org.keycloak.provider.ProviderConfigProperty;
+import org.keycloak.provider.ProviderConfigurationBuilder;
 
 final class FranceConnectIdentityProviderConfig extends AbstractBaseProviderConfig {
 
@@ -30,5 +36,32 @@ final class FranceConnectIdentityProviderConfig extends AbstractBaseProviderConf
   @Override
   protected List<IdentityProviderMapperModel> getDefaultMappers() {
     return FC_PROVIDER_MAPPERS;
+  }
+
+  public static List<ProviderConfigProperty> getConfigProperties() {
+    List<String> environments = Stream.of(FCEnvironment.values())
+        .map(Enum::name)
+        .collect(Collectors.toList());
+
+    List<String> eidasLevels = Stream.of(EidasLevel.values())
+        .map(Enum::name)
+        .collect(Collectors.toList());
+
+    return ProviderConfigurationBuilder.create()
+        .property().name(FCEnvironment.ENVIRONMENT_PROPERTY_NAME)
+          .label("Environnement FranceConnect")
+          .helpText("Permet de choisir l'environnement FranceConnect. Effet : change les urls vers FranceConnect.")
+          .type(ProviderConfigProperty.LIST_TYPE)
+          .options(environments)
+          .defaultValue(DEFAULT_FC_ENVIRONMENT)
+          .add()
+        .property().name(EidasLevel.EIDAS_LEVEL_PROPERTY_NAME)
+          .label("Niveau de garantie eIDAS")
+          .helpText("Permet de fixer le niveau de garantie du compte utilisateur souhaité. Effet : désactive des fournisseurs d'identités (FI) sur la page de login FranceConnect.")
+          .type(ProviderConfigProperty.LIST_TYPE)
+          .options(eidasLevels)
+          .defaultValue(EidasLevel.EIDAS1)
+          .add()
+        .build();
   }
 }

--- a/src/main/java/fr/insee/keycloak/providers/franceconnect/FranceConnectIdentityProviderFactory.java
+++ b/src/main/java/fr/insee/keycloak/providers/franceconnect/FranceConnectIdentityProviderFactory.java
@@ -5,6 +5,7 @@ import org.keycloak.broker.social.SocialIdentityProviderFactory;
 import org.keycloak.models.IdentityProviderMapperModel;
 import org.keycloak.models.IdentityProviderModel;
 import org.keycloak.models.KeycloakSession;
+import org.keycloak.provider.ProviderConfigProperty;
 
 import java.util.List;
 
@@ -45,5 +46,10 @@ public final class FranceConnectIdentityProviderFactory
   @Override
   public FranceConnectIdentityProviderConfig createConfig() {
     return new FranceConnectIdentityProviderConfig();
+  }
+
+  @Override
+  public List<ProviderConfigProperty> getConfigProperties() {
+    return FranceConnectIdentityProviderConfig.getConfigProperties();
   }
 }


### PR DESCRIPTION
fix #74

![Screenshot 2024-03-29 at 16-47-57 Keycloak Administration UI](https://github.com/InseeFr/Keycloak-FranceConnect/assets/116001482/0d4ada7f-3315-4845-9991-eb527aeac988)

Les URL utilisées sont correspondent bien à l'environnement FC sélectionné et le niveau eIDAS est bien pris en compte dans le paramètre `acr_values`, ça semble fonctionner comme attendu, mais je n'ai pas pu réellement tester la modification (voir #102).

